### PR TITLE
Typo in man file.

### DIFF
--- a/genup.8
+++ b/genup.8
@@ -187,7 +187,7 @@ eponymous USE flag has been enabled.
 Displays a short help screen, and exits.
 .TP
 .BR \-i ", " \-\-ignore\-required\-changes
-By default, wqhen running in non-interactive mode, \fBgenup\fR checks to see if
+By default, when running in non-interactive mode, \fBgenup\fR checks to see if
 the \fBemerge @world\fR step would fail due to required user changes
 (to \fI/etc/portage/package.use\fR etc.), and stops with an error if so.
 This option suppresses that check.


### PR DESCRIPTION
There was a typo in the man file, concerning the '--ignore-required-changes' flag to genup.